### PR TITLE
fixed issue with progress bar showing full as well as card deck order

### DIFF
--- a/src/CardApp/CardDeck.js
+++ b/src/CardApp/CardDeck.js
@@ -71,11 +71,9 @@ const CardDeck = () => {
   const { deck, totalCount, sendToYes, sendToMaybe, sendToNo } = useDeck()
   const { initial: currentDeck, yes } = deck
 
-  const getCurrentIndex = () => {
-    return totalCount - currentDeck.length + 1
-  }
+  const currentIndex = totalCount - currentDeck.length + 1
 
-  const progress = Math.ceil((getCurrentIndex() * 100) / totalCount)
+  const progress = Math.ceil((currentIndex * 100) / totalCount)
 
   const current =
     currentDeck && currentDeck.length > 0

--- a/src/state/deck-provider.js
+++ b/src/state/deck-provider.js
@@ -4,7 +4,7 @@ import initialDeck from '../static/spark_paths'
 const DeckContext = React.createContext()
 
 export const initialDeckState = {
-  initial: initialDeck.paths.sort(() => -1),
+  initial: initialDeck.paths, // initialDeck.paths.sort(() => -1),
   no: [],
   maybe: [],
   yes: [],
@@ -14,7 +14,7 @@ export const initialDeckState = {
 function DeckProvider(props) {
   const [history, setHistory] = useState()
   const [deck, setDeck] = useState(initialDeckState)
-  const [totalCount, setTotalCount] = useState(initialDeckState.length)
+  const [totalCount, setTotalCount] = useState(initialDeckState.totalCount)
 
   const undo = () => {
     if (history) {

--- a/src/state/deck-provider.js
+++ b/src/state/deck-provider.js
@@ -4,7 +4,7 @@ import initialDeck from '../static/spark_paths'
 const DeckContext = React.createContext()
 
 export const initialDeckState = {
-  initial: initialDeck.paths, // initialDeck.paths.sort(() => -1),
+  initial: initialDeck.paths,
   no: [],
   maybe: [],
   yes: [],


### PR DESCRIPTION
The deck was originally sorted in reverse in order to render it stacked, but this was refactored resulting in the deck being backward.  Fixed.

The totalCount value wasn't being loaded into the DeckProvider properly causing the progress bar to show full at all times. Fixed